### PR TITLE
Only do row selection if there are rows to select - otherwise table won't render

### DIFF
--- a/methods.R
+++ b/methods.R
@@ -47,13 +47,13 @@ create_fig <- function(x, y, y_new){
 }
 
 dt_show_issues <- function(x){
-
+  
   display_data <- x %>%
     mutate(new_contributor = author_association %in% c("NONE", "FIRST_TIME_CONTRIBUTOR")) %>%
     select(created_at, url_title, html_url, new_contributor)
 
   selected_rows <- which(display_data$new_contributor == TRUE)
-  DT::datatable(
+  dt <- DT::datatable(
     select(display_data, -new_contributor),
     rownames = FALSE,
     colnames = c('Date', 'GitHub title', 'GitHub link'),
@@ -65,8 +65,15 @@ dt_show_issues <- function(x){
       pageLength = 10
     )
   ) %>%
-    formatDate("created_at", method = "toDateString") %>%
-    formatStyle("created_at", target = "row", backgroundColor = styleRow(selected_rows, '#fbcd9989'))
+    formatDate("created_at", method = "toDateString")
+  
+  if(length(selected_rows) > 0){
+    dt <- dt %>%
+      formatStyle("created_at", target = "row", backgroundColor = styleRow(selected_rows, '#fbcd9989'))
+  }
+  
+  dt
+  
 }
 
 dt_show_emails <- function(x){


### PR DESCRIPTION
Fixes #28 

@AlenkaF  - you were right - the bug was in the datatable.  Basically, the code which adds the highlighting was great, but when the rows selected ends up being an empty integer vector (i.e. if there are no rows to select with those properties), the table won't render. 

I've updated this now to only do highlighting if there's something to highlight.