### PR TITLE
Add links to threads for mailing list summary

### DIFF
--- a/ml_data/prompt_ml_summary.txt
+++ b/ml_data/prompt_ml_summary.txt
@@ -13,6 +13,7 @@ highlight potential challenges.
 - Include 3-5 bullet points for each of the topics: "ongoing discussions"", "emerging themes",
 "potential roadblocks", and "strategic plans".
 - For each bullet point, include titles of any threads for the relevant discussion(s) and one or more links using the format "[Thread](https://lists.apache.org/list?dev@arrow.apache.org:lte=2M:<thread_title>)".  The link text should always just say "Thread". You can include more than one for each topic - as many as necessary. The thread title should always be URL encoded.
+- Don't include links to threads talking about the mailing list summary on the dashboard.
 - Include the topics as h2 headings in markdown format, i.e. '# Heading'
 - Don't add unnecessary fluff or intros or conclusions, just give me the overview
 

--- a/ml_data/prompt_ml_summary.txt
+++ b/ml_data/prompt_ml_summary.txt
@@ -12,13 +12,15 @@ highlight potential challenges.
 # output style
 - Include 3-5 bullet points for each of the topics: "ongoing discussions"", "emerging themes",
 "potential roadblocks", and "strategic plans".
+- For each bullet point, include titles of any threads for the relevant discussion(s) and one or more links using the format "[Thread](https://lists.apache.org/list?dev@arrow.apache.org:lte=2M:<thread_title>)".  The link text should always just say "Thread". You can include more than one for each topic - as many as necessary. The thread title should always be URL encoded.
 - Include the topics as h2 headings in markdown format, i.e. '# Heading'
 - Don't add unnecessary fluff or intros or conclusions, just give me the overview
-- Reference specific dates where items were mentioned, e.g. "(23 March").
+
 
 # example of a good output
 
 Here's a partial example of good output:
 '## Ongoing Discussions
 
-*   **Language Implementation Decoupling:** Splitting language implementations (JS, Swift) into separate repositories remains a central theme. Focus is on independent releases, reduced maintenance burdens, and language-specific adaptation (May 6, May 16).'
+*   **Language Implementation Decoupling:**
+Splitting language implementations (JS, Swift) into separate repositories remains a central theme. Focus is on independent releases, reduced maintenance burdens, and language-specific adaptation: [Thread 1](https://lists.apache.org/list?dev@arrow.apache.org:lte=2M:Split%20Swift%20to%20separated%20repository) [Thread 2](https://lists.apache.org/list?dev@arrow.apache.org:lte=2M:Other%20%Swift)'

--- a/overall_summary.qmd
+++ b/overall_summary.qmd
@@ -11,6 +11,8 @@ summary = llm_ml.summarise_dev_ml()
 
 #### Column 
 
+The content below is an LLM summary of this month's activity on the mailing list.
+
 ::: {.card}
 `r py$summary`
 :::


### PR DESCRIPTION
This PR adds links to search for mailing list threads in the mailing list viewer.