### PR TITLE
Use most recent date <= month-ago when computing 1-month change

### DIFF
--- a/maintenance_stats.qmd
+++ b/maintenance_stats.qmd
@@ -28,7 +28,9 @@ current_issues <- open_counts %>%
   pull(open_issues)
 
 month_ago_issues <- open_counts %>%
-  filter(date == month_ago_date) %>%
+  filter(date <= month_ago_date) %>%
+  arrange(desc(date)) %>%
+  slice(1) %>%
   pull(open_issues)
 
 current_prs <- open_counts %>%
@@ -36,7 +38,9 @@ current_prs <- open_counts %>%
   pull(open_prs)
 
 month_ago_prs <- open_counts %>%
-  filter(date == month_ago_date) %>%
+  filter(date <= month_ago_date) %>%
+  arrange(desc(date)) %>%
+  slice(1) %>%
   pull(open_prs)
 
 change_issues <- current_issues - month_ago_issues


### PR DESCRIPTION
open_counts.csv has occasional gaps (e.g. 2026-03-27 through 03-29 are missing). When max(date) %m-% months(1) lands inside a gap, filter(date == month_ago_date) returns 0 rows, change_prs / change_issues become length 0, and get_sign_string()'s switch(as.character(sign(x))) errors with "EXPR must be a length 1 vector", crashing the Quarto render and the publish workflow.

Pick the most recent available date on or before month_ago_date instead.